### PR TITLE
`basestring` variable not used in Python 3, add compatibility layer

### DIFF
--- a/basc_py4chan/board.py
+++ b/basc_py4chan/board.py
@@ -9,6 +9,23 @@ from .thread import Thread
 # cached metadata for boards
 _metadata = {}
 
+# compatibility layer for Python2's `basestring` variable
+# http://www.rfk.id.au/blog/entry/preparing-pyenchant-for-python-3/
+try:
+    unicode = unicode
+except NameError:
+    # 'unicode' is undefined, must be Python 3
+    str = str
+    unicode = str
+    bytes = bytes
+    basestring = (str,bytes)
+else:
+    # 'unicode' exists, must be Python 2
+    str = str
+    unicode = unicode
+    bytes = str
+    basestring = basestring
+
 
 def _fetch_boards_metadata():
     if not _metadata:


### PR DESCRIPTION
Since all strings are Unicode in Python 3, the variables `unicode` and `basestring` are no longer used. This patch makes these variables work again in Python 3.

http://www.rfk.id.au/blog/entry/preparing-pyenchant-for-python-3/

However, the real solution is to modify `get_boards()` such that it no longer needs to use `basestring`. Though it has to be done in a way that both Python 2 and 3 will accept.