### PR TITLE
New URL Class for increased extendability

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,29 +63,27 @@ So instead of writing a whole new class from scratch, you could inherit and over
 .. code:: python
     import basc_py4chan
     
-    # new site's API URL structure
-    URL = {
-        'api': 'a.4cdn.org',          # API subdomain
-        'boards': 'boards.4chan.org', # HTML subdomain
-        'images': 'i.4cdn.org',       # image host
-        'thumbs': 't.4cdn.org',       # thumbs host
-        'template': {
-            'board': '{name}/%s.json',
-            'thread': '{name}/thread/%s.json'
-        },
-         'all_threads': 'threads',             # json entry for threads
-         'catalog_dir': 'catalog',             # catalog directory 
-         'boards_list': 'https://a.4cdn.org/boards.json' # list of all boards
-    }
+    class URL (basc_py4chan.URL):
+        # see BASC-py4chan's `url.py` for an example of how to set up
+        # the URLs.
+        def __init__(self, https=False):
+            # Your API URL Subdomains
+            DOMAIN = { }
+            
+            # Your API URL Templates
+            TEMPLATE = { }
+            
+            # Your API Listings
+            LISTING = { }
+            
+            # combine all dictionaries into self.URL dictionary
+            self.URL = TEMPLATE
+            self.URL.update({'domain': DOMAIN})
+            self.URL.update({'listing': LISTING})
     
     class Board(basc_py4chan.Board):
-        # override the `boards_list` variable with URL struct
-        def _fetch_boards_metadata(boards_list=URL['boards_list']):
-            super(boards_list)
-
-        # redeclare to use our URL structs
-        def __init__(self, board_name, https=False, site_urls=URL, session=None):
-           super(board_name, https=False, site_urls=URL, session=None)
+        # add your own overrides here, or leave it alone
+        pass
            
     class Thread(basc_py4chan.Threads):
         # add your own overrides here, or leave it alone
@@ -100,7 +98,7 @@ So instead of writing a whole new class from scratch, you could inherit and over
 
 From there, just override any methods in classes Board, Thread or Post as necessary. 
 
-Notice that if your imageboard's API does not support a certain feature in the 4chan API, you should have the function return NULL.
+Notice that if your imageboard's API does not support a certain feature in the 4chan API, `you should have the function raise an AttributeError. <http://stackoverflow.com/a/23126260>`_
 
 License
 -------

--- a/basc_py4chan/__init__.py
+++ b/basc_py4chan/__init__.py
@@ -12,7 +12,7 @@ and an object-oriented way to browse and get board and thread
 information quickly and easily.
 """
 
-__version__ = '0.4.3'
+__version__ = '0.5.0'
 
 from .board import Board, board, get_boards, get_all_boards
 from .thread import Thread

--- a/basc_py4chan/board.py
+++ b/basc_py4chan/board.py
@@ -3,30 +3,17 @@
 import requests
 
 from . import __version__
-from .url import URL
 from .thread import Thread
+from .url import Url
 
 # cached metadata for boards
 _metadata = {}
 
 
-def _fetch_boards_metadata(boards_list=URL['boards_list']):
-    """Used by get_boards() to retrieve a list of boards and 
-    their metadata via the 4chan API.
-    
-    If you are making a derived class (for 420chan or 8chan)
-    you MUST inherit and override this method with:
-        def _fetch_boards_metadata(boards_list="http://new-api-url/boards.json"):
-            super(boards_list)
-
-    Args:
-        boards_list (string): API URL to obtain the boards
-        list from. For 4chan, it is something like
-        'https://a.4cdn.org/boards.json'
-    """
-    
+def _fetch_boards_metadata():
+    _url = Url()      # quick and dirty 4chan URL generator
     if not _metadata:
-        resp = requests.get(boards_list)
+        resp = requests.get(_url.board_list())
         resp.raise_for_status()
         data = {entry['board']: entry for entry in resp.json()['boards']}
         _metadata.update(data)
@@ -72,36 +59,29 @@ class Board(object):
         page_count (int): How many pages this board has.
         threads_per_page (int): How many threads there are on each page.
     """
-    def __init__(self, board_name, https=False, site_urls=URL, session=None):
+    def __init__(self, board_name, https=False, session=None):
         """Creates a :mod:`basc_py4chan.Board` object.
 
         Args:
             board_name (string): Name of the board, such as "tg" or "etc".
             https (bool): Whether to use a secure connection to 4chan.
-            site_urls: A Python dictionary defining which API URLs to access. See url.py for example contents. By default, it is set to the 4chan API using the 'url.py' file. However, the user (or better yet, derived classes) can choose to use another compatible API, such as 8chan/vichan or 420chan.
             session: Existing requests.session object to use instead of our current one.
         """
         self._board_name = board_name
+        self._https = https
         self._protocol = 'https://' if https else 'http://'
-        self._base_url = self._protocol + site_urls['api']
+        self._url = Url(board=board_name, https=self._https)
 
         self._requests_session = session or requests.session()
         self._requests_session.headers['User-Agent'] = 'py-4chan/%s' % __version__
-
-        self._board_path = '%s/%s' % (self._base_url,
-                                      site_urls['template']['board'].format(name=board_name))
-        self._thread_path = '%s/%s' % (self._base_url,
-                                       site_urls['template']['thread'].format(name=board_name))
-
-        self._site_urls = site_urls
 
         self._thread_cache = {}
 
     def _get_metadata(self, key):
         return _get_board_metadata(self._board_name, key)
 
-    def _get_json(self, path):
-        res = self._requests_session.get(self._board_path % path)
+    def _get_json(self, url):
+        res = self._requests_session.get(url)
         res.raise_for_status()
         return res.json()
 
@@ -123,7 +103,11 @@ class Board(object):
                 cached_thread.update()
             return cached_thread
 
-        res = self._requests_session.get(self._thread_path % thread_id)
+        res = self._requests_session.get(
+            self._url.thread_api_url(
+                thread_id = thread_id
+                )
+        )
 
         # check if thread exists
         if raise_404:
@@ -145,7 +129,11 @@ class Board(object):
         Returns:
             bool: Whether the given thread exists on this board.
         """
-        return self._requests_session.head(self._thread_path % thread_id).ok
+        return self._requests_session.head(
+            self._url.thread_api_url(
+                thread_id=thread_id
+                )
+        ).ok
 
     def _catalog_to_threads(self, json):
         threads_json = [thread for page in json for thread in page['threads']]
@@ -157,10 +145,10 @@ class Board(object):
 
         return thread_list
 
-    def _request_threads(self, page):
-        json = self._get_json(page)
+    def _request_threads(self, url):
+        json = self._get_json(url)
 
-        if page == site_urls['catalog_dir']:
+        if url == self._url.catalog():
             thread_list = self._catalog_to_threads(json)
         else:
             thread_list = json['threads']
@@ -202,7 +190,7 @@ class Board(object):
         Returns:
             list of ints: List of IDs of every thread on this board.
         """
-        json = self._get_json(site_urls['all_threads'])
+        json = self._get_json(self._url.thread_list())
         return [thread['no'] for page in json for thread in page['threads']]
 
     def get_all_threads(self, expand=False):
@@ -224,7 +212,7 @@ class Board(object):
             list of :mod:`basc_py4chan.Thread`: List of Thread objects representing every thread on this board.
         """
         if not expand:
-            return self._request_threads(site_urls['catalog_dir'])
+            return self._request_threads(self._url.catalog())
 
         thread_ids = self.get_all_thread_ids()
         threads = [self.get_thread(id, raise_404=False) for id in thread_ids]
@@ -266,12 +254,8 @@ class Board(object):
         return self._get_metadata('per_page')
 
     @property
-    def site_urls(self):
-        """ Returns a Python dictionary defining which API URLs to access.
-        
-        Meant to be used internally by thread.py and post.py, ensuring that they obtain the URL to use from boards.py.
-        """
-        return self._site_urls
+    def https(self):
+        return self._https
 
     def __repr__(self):
         return '<Board /%s/>' % self.name

--- a/basc_py4chan/board.py
+++ b/basc_py4chan/board.py
@@ -28,9 +28,8 @@ else:
 
 
 def _fetch_boards_metadata():
-    _url = Url()      # quick and dirty 4chan URL generator
     if not _metadata:
-        resp = requests.get(_url.board_list())
+        resp = requests.get(Url.board_list())
         resp.raise_for_status()
         data = {entry['board']: entry for entry in resp.json()['boards']}
         _metadata.update(data)

--- a/basc_py4chan/post.py
+++ b/basc_py4chan/post.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 
+from .url import Url
 from .util import clean_comment_body
 
 
@@ -42,6 +43,7 @@ class Post(object):
     def __init__(self, thread, data):
         self._thread = thread
         self._data = data
+        self._url = Url(board=self._thread._board.name, https=thread.https)		# 4chan URL generator
 
     @property
     def is_op(self):
@@ -125,10 +127,7 @@ class Post(object):
             return None
 
         board = self._thread._board
-        return '%s%s/%s/%i%s' % (
-            board._protocol,
-            board.site_urls['images'],
-            board.name,
+        return self._url.file_url(
             self._data['tim'],
             self._data['ext']
         )
@@ -178,10 +177,7 @@ class Post(object):
             return None
 
         board = self._thread._board
-        return '%s%s/%s/%is.jpg' % (
-            board._protocol,
-            board.site_urls['thumbs'],
-            board.name,
+        return self._url.thumb_url(
             self._data['tim']
         )
 

--- a/basc_py4chan/thread.py
+++ b/basc_py4chan/thread.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from .post import Post
+from .url import Url
 
 
 class Thread(object):
@@ -18,6 +19,7 @@ class Thread(object):
     """
     def __init__(self, board, id):
         self._board = board
+        self._url = Url(board=board.name, https=board.https)       # 4chan URL generator
         self.id = self.number = self.num = self.no = id
         self.topic = None
         self.replies = []
@@ -33,7 +35,7 @@ class Thread(object):
 
     @property
     def _api_url(self):
-        return self._board._thread_path % self.id
+        return self._url.thread_api_url(self.id)
 
     @property
     def closed(self):
@@ -198,14 +200,12 @@ class Thread(object):
         return self.posts
 
     @property
+    def https(self):
+        return self._board._https
+
+    @property
     def url(self):
-        board = self._board
-        return '%s%s/%s/thread/%i' % (
-            board._protocol,
-            board.site_urls['boards'],
-            board.name,
-            self.id
-        )
+        return _url.thread_url(self.id)
 
     @property
     def semantic_url(self):

--- a/basc_py4chan/thread.py
+++ b/basc_py4chan/thread.py
@@ -205,7 +205,7 @@ class Thread(object):
 
     @property
     def url(self):
-        return _url.thread_url(self.id)
+        return self._url.thread_url(self.id)
 
     @property
     def semantic_url(self):

--- a/basc_py4chan/url.py
+++ b/basc_py4chan/url.py
@@ -1,15 +1,129 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-URL = {
-    'api': 'a.4cdn.org',          # API subdomain
-    'boards': 'boards.4chan.org', # HTML subdomain
-    'images': 'i.4cdn.org',       # image host
-    'thumbs': 't.4cdn.org',       # thumbs host
-    'template': {
-        'board': '{name}/%s.json',
-        'thread': '{name}/thread/%s.json'
-    },
-    'all_threads': 'threads',             # json entry for threads
-    'catalog_dir': 'catalog',             # catalog directory 
-    'boards_list': 'https://a.4cdn.org/boards.json'
+
+# 4chan URL generator. Inherit and override this for derivative classes  (e.g. 420chan API, 8chan/vichan API)
+class Url():
+    def __init__(self, board='*', https=False):
+        self._board = board
+        self._protocol = 'https://' if https else 'http://'
+        
+        # 4chan API URL Subdomains
+        DOMAIN = {
+            'api': self._protocol + 'a.4cdn.org',   # API subdomain
+            'boards': self._protocol + 'boards.4chan.org', # HTML subdomain
+            'file': self._protocol + 'i.4cdn.org',  # file (image) host
+            'thumbs': self._protocol + 'i.4cdn.org',# thumbs host
+            'static': self._protocol + 's.4cdn.org' # static host
+        }
+        
+        # 4chan API URL Templates
+        TEMPLATE = {
+            'api': {  # URL structure templates
+                'board': DOMAIN['api'] + '/{board}/{page}.json',
+                'thread': DOMAIN['api'] + '/{board}/thread/{thread_id}.json'
+            },
+            'http': { # Standard HTTP viewing URLs
+                'board': DOMAIN['boards'] + '/{board}/{page}.json',
+                'thread': DOMAIN['boards'] + '/{board}/thread/{thread_id}'
+            },
+            'data': {
+                'file': DOMAIN['file'] + '/{board}/{tim}{ext}',
+                'thumbs': DOMAIN['thumbs'] + '/{board}/{tim}s.jpg',
+                'static': DOMAIN['static'] + '/image/{item}'
+            }
+        }
+        
+        # 4chan API Listings
+        LISTING = {
+            'board_list': DOMAIN['api'] + '/boards.json',
+            'thread_list': DOMAIN['api'] + '/{board}/threads.json',
+            'archived_thread_list': DOMAIN['api'] + '/{board}/archive.json',
+            'catalog': DOMAIN['api'] + '/{board}/catalog.json'
+        }
+        
+        # combine all dictionaries into self.URL dictionary
+        self.URL = TEMPLATE
+        self.URL.update({'domain': DOMAIN})
+        self.URL.update({'listing': LISTING})
+
+    # generate boards listing URL
+    def board_list(self):
+        return self.URL['listing']['board_list']
+
+    # generate board page URL
+    def page_url(self, page):
+        return self.URL['api']['board'].format(
+            board=self._board,
+            page=page
+            )
+
+    # generate catalog URL
+    def catalog(self):
+        return self.URL['listing']['catalog'].format(
+            board=self._board
+            )
+
+    # generate threads listing URL
+    def thread_list(self):
+        return self.URL['listing']['thread_list'].format(
+            board=self._board
+            )
+
+    # generate archived threads listing URL
+    def archived_thread_list(self):
+        return self.URL['listing']['archived_thread_list'].format(
+            board=self._board
+            )
+
+    # generate API thread URL
+    def thread_api_url(self, thread_id):
+        return self.URL['api']['thread'].format(
+            board=self._board,
+            thread_id=thread_id
+            )
+
+    # generate HTTP thread URL
+    def thread_url(self, thread_id):
+        return self.URL['http']['thread'].format(
+            board=self._board,
+            thread_id=thread_id
+            )
+
+    # generate file URL
+    def file_url(self, tim, ext):
+        return self.URL['data']['file'].format(
+            board=self._board,
+            tim=tim,
+            ext=ext
+            )
+
+    # generate thumb URL
+    def thumb_url(self, tim):
+        return self.URL['data']['thumbs'].format(
+            board=self._board,
+            tim=tim
+            )
+
+    # return entire URL dictionary
+    @property
+    def site_urls(self):
+        return self._site_urls
+
+"""
+# 4chan Static Data (Unique to 4chan, needs implementation)
+STATIC = {
+    'flags': DOMAIN['static'] + '/image/country/{country}.gif',
+    'pol_flags': DOMAIN['static'] + '/image/country/troll/{country}.gif',
+    'spoiler': { # all known custom spoiler images, just fyi
+        'default': DOMAIN['static'] + '/image/spoiler.png',
+        'a': DOMAIN['static'] + '/image/spoiler-a.png',
+        'co': DOMAIN['static'] + '/image/spoiler-co.png',
+        'mlp': DOMAIN['static'] + '/image/spoiler-mlp.png',
+        'tg': DOMAIN['static'] + '/image/spoiler-tg.png',
+        'tg-alt': DOMAIN['static'] + '/image/spoiler-tg2.png',
+        'v': DOMAIN['static'] + '/image/spoiler-v.png',
+        'vp': DOMAIN['static'] + '/image/spoiler-vp.png',
+        'vr': DOMAIN['static'] + '/image/spoiler-vr.png'
+    }
 }
+"""

--- a/basc_py4chan/url.py
+++ b/basc_py4chan/url.py
@@ -3,7 +3,8 @@
 
 # 4chan URL generator. Inherit and override this for derivative classes  (e.g. 420chan API, 8chan/vichan API)
 class Url():
-    def __init__(self, board='*', https=False):
+    # default value for board in case user wants to query board list
+    def __init__(self, board, https=False):
         self._board = board
         self._protocol = 'https://' if https else 'http://'
         
@@ -47,6 +48,8 @@ class Url():
         self.URL.update({'listing': LISTING})
 
     # generate boards listing URL
+    # static so you can use anytime without instantiating
+    @staticmethod
     def board_list(self):
         return self.URL['listing']['board_list']
 
@@ -69,11 +72,11 @@ class Url():
             board=self._board
             )
 
-    # generate archived threads listing URL
-    def archived_thread_list(self):
-        return self.URL['listing']['archived_thread_list'].format(
-            board=self._board
-            )
+#    # generate archived threads list URL (disabled for compatibility)
+#    def archived_thread_list(self):
+#        return self.URL['listing']['archived_thread_list'].format(
+#            board=self._board
+#            )
 
     # generate API thread URL
     def thread_api_url(self, thread_id):

--- a/basc_py4chan/url.py
+++ b/basc_py4chan/url.py
@@ -107,7 +107,7 @@ class Url():
     # return entire URL dictionary
     @property
     def site_urls(self):
-        return self._site_urls
+        return self.URL
 
 """
 # 4chan Static Data (Unique to 4chan, needs implementation)


### PR DESCRIPTION
I wrote up a new Url class, which puts all 4chan API URLs in one handy place. This way, URL construction is done in this class and can be easily reused. In fact, it might be helpful to use in our BASC-Archiver.

This replaces the limited URL dictionary.

A Url Class also makes it possible for derived classes to inherit and override the typical 4chan API URL settings, so 8chan/vichan or 420chan (which have similar APIs) can be supported by just tweaking the URLs a bit.

This way, we can create a possible py8chan or py420chan with a few overrides, and reduce code redundancy.