### PR TITLE
Prevent RuntimeError when refreshing the board cache

### DIFF
--- a/basc_py4chan/board.py
+++ b/basc_py4chan/board.py
@@ -237,7 +237,7 @@ class Board(object):
 
     def refresh_cache(self, if_want_update=False):
         """Update all threads currently stored in our cache."""
-        for thread in self._thread_cache.values():
+        for thread in tuple(self._thread_cache.values()):
             if if_want_update:
                 if not thread.want_update:
                     continue


### PR DESCRIPTION
By wrapping the dict values in a tuple and iterating over it instead, a
copy of the references contained within is made, and is thus unaffected
by the underlying dictionary changing size during runtime.

Calling a thread's update method may lead to the thread modifying the
board's cache during the iteration, leading to the described
RuntimeError.