### PR TITLE
Added filename_original attribute for getting original name

### DIFF
--- a/basc_py4chan/file.py
+++ b/basc_py4chan/file.py
@@ -15,7 +15,8 @@ class File(object):
     Attributes:
         file_md5 (string): MD5 hash of the file attached to this post.
         file_md5_hex (string): Hex-encoded MD5 hash of the file attached to this post.
-        filename (string): Original name of the file attached to this post.
+        filename (string): Name of the file attached to this post.
+        filename_original (string): Original name of the file attached to this post.
         file_url (string): URL of the file attached to this post.
         file_extension (string): Extension of the file attached to this post. Eg: ``png``, ``webm``, etc.
         file_size (int): Size of the file attached to this post.
@@ -49,6 +50,13 @@ class File(object):
     def filename(self):
         return '%s%s' % (
             self._data['tim'],
+            self._data['ext']
+        )
+
+    @property
+    def filename_original(self):
+        return '%s%s' % (
+            self._data['filename'],
             self._data['ext']
         )
 


### PR DESCRIPTION
filename attribute only returns the renamed UNIX timestamp one.