### PR TITLE
4chan giving up 4cdn, part 1: files and thumbs

### DIFF
--- a/basc_py4chan/url.py
+++ b/basc_py4chan/url.py
@@ -12,8 +12,8 @@ class Url(object):
         DOMAIN = {
             'api': self._protocol + 'a.4cdn.org',   # API subdomain
             'boards': self._protocol + 'boards.4chan.org', # HTML subdomain
-            'file': self._protocol + 'i.4cdn.org',  # file (image) host
-            'thumbs': self._protocol + 'i.4cdn.org',# thumbs host
+            'file': self._protocol + 'is.4chan.org',  # file (image) host
+            'thumbs': self._protocol + 'is.4chan.org',# thumbs host
             'static': self._protocol + 's.4cdn.org' # static host
         }
         


### PR DESCRIPTION
Hiro wants to cut some costs and remove the `4cdn.org` domain (and CDN?).
He already started with the files and thumbs.

Some users are now getting errors from `i.4cdn.org`, so we should update the code.