### PR TITLE
util.py fix for python 3.9 & Greater

### DIFF
--- a/basc_py4chan/util.py
+++ b/basc_py4chan/util.py
@@ -3,14 +3,9 @@
 """Utility functions."""
 
 import re
+import html
 
-# HTML parser was renamed in python 3.x
-try:
-    from html.parser import HTMLParser
-except ImportError:
-    from HTMLParser import HTMLParser
-
-_parser = HTMLParser()
+_parser = html
 
 
 def clean_comment_body(body):

--- a/basc_py4chan/util.py
+++ b/basc_py4chan/util.py
@@ -4,9 +4,19 @@
 
 import re
 import html
+import sys
 
-_parser = html
+#HTML parser compat fix for python 3.9 and onwards
+if sys.version_info[0] == 3 and sys.version_info[1] >= 9:
+    _parser = html
+else:
+    # HTML parser was renamed in python 3.x
+    try:
+        from html.parser import HTMLParser
+    except ImportError:
+        from HTMLParser import HTMLParser
 
+    _parser = HTMLParser()
 
 def clean_comment_body(body):
     """Returns given comment HTML as plaintext.

--- a/basc_py4chan/util.py
+++ b/basc_py4chan/util.py
@@ -3,12 +3,12 @@
 """Utility functions."""
 
 import re
-import html
 import sys
 
 #HTML parser compat fix for python 3.9 and onwards
 if sys.version_info[0] == 3 and sys.version_info[1] >= 9:
-    _parser = html
+    import html
+    _parser = html 
 else:
     # HTML parser was renamed in python 3.x
     try:


### PR DESCRIPTION
Updated util.py to use compliant html call for python 3.9 and up while retaining functionality for older versions of python